### PR TITLE
feat: add support for 'zod/mini' import source

### DIFF
--- a/src/rules/consistent-import-source.spec.ts
+++ b/src/rules/consistent-import-source.spec.ts
@@ -9,6 +9,7 @@ ruleTester.run('consistent-import-source', consistentImportSource, {
     { code: 'import z from "zod"' },
     { code: 'import z from "zod"', options: [{ sources: ['zod'] }] },
     { code: 'import z from "zod/v4"', options: [{ sources: ['zod/v4'] }] },
+    { code: 'import z from "zod/mini"', options: [{ sources: ['zod/mini'] }] },
   ],
   invalid: [
     {
@@ -27,6 +28,15 @@ ruleTester.run('consistent-import-source', consistentImportSource, {
         {
           messageId: 'sourceNotAllowed',
           data: { source: 'zod/v4', sources: '"zod"' },
+        },
+      ],
+    },
+    {
+      code: 'import z from "zod/mini"',
+      errors: [
+        {
+          messageId: 'sourceNotAllowed',
+          data: { source: 'zod/mini', sources: '"zod"' },
         },
       ],
     },

--- a/src/rules/consistent-import-source.ts
+++ b/src/rules/consistent-import-source.ts
@@ -2,7 +2,7 @@ import { ESLintUtils } from '@typescript-eslint/utils';
 
 import { getRuleURL } from '../meta.js';
 
-const ZOD_IMPORT_SOURCES = ['zod', 'zod/v4', 'zod/v3'] as const;
+const ZOD_IMPORT_SOURCES = ['zod', 'zod/mini', 'zod/v4', 'zod/v3'] as const;
 
 type ZodImportSource = (typeof ZOD_IMPORT_SOURCES)[number];
 


### PR DESCRIPTION
This pull request updates the `consistent-import-source` ESLint rule to support and validate the new `zod/mini` import source. The changes ensure that `zod/mini` is recognized as a valid import source and is properly tested for both valid and invalid usage scenarios.

Thanks for your work on this plugin